### PR TITLE
Create Initial Opensearch Indices

### DIFF
--- a/dashboards/scripts/shared-object-creation.sh
+++ b/dashboards/scripts/shared-object-creation.sh
@@ -425,6 +425,17 @@ if [[ "${CREATE_OS_ARKIME_SESSION_INDEX:-true}" = "true" ]] ; then
             # end OpenSearch Tweaks
             #############################################################################################################################
 
+            
+            # OpenSearch Create Initial Indices
+
+            curl "${CURL_CONFIG_PARAMS[@]}" -w "\n" --location --silent --output /dev/null --show-error \
+              -XPUT "$OPENSEARCH_URL_TO_USE/${MALCOLM_NETWORK_INDEX_PATTERN%?}initial" \
+              -H "$XSRF_HEADER:true" -H 'Content-type:application/json'
+
+            curl "${CURL_CONFIG_PARAMS[@]}" -w "\n" --location --silent --output /dev/null --show-error \
+              -XPUT "$OPENSEARCH_URL_TO_USE/${MALCOLM_OTHER_INDEX_PATTERN%?}initial" \
+              -H "$XSRF_HEADER:true" -H 'Content-type:application/json'
+
             # before we go on to create the anomaly detectors, we need to wait for actual network log documents
             /data/opensearch_status.sh -w >/dev/null 2>&1
             sleep 60


### PR DESCRIPTION
Closes #527 

Today, if you open Dashboards without any data in the indexes you get spammed with this message about a thousand times about how there's no matching index for the arkime-sessions3-* index pattern or the malcolm_beats-* pattern.

This change creates an empty index to suppress the message. These empty indices are called:

<MALCOLM_NETWORK_INDEX_PATTERN>initial
and
<MALCOLM_OTHER_INDEX_PATTERN>initial
The program drops the trailing asterisk in the index patterns.