### PR TITLE
Making suricata run in socket mode for pcap processing improvement

### DIFF
--- a/kubernetes/33-suricata-socket.yml
+++ b/kubernetes/33-suricata-socket.yml
@@ -1,0 +1,81 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: suricata-socket-deployment
+  namespace: malcolm
+spec:
+  selector:
+    matchLabels:
+      name: suricata-socket-deployment
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: suricata-socket-deployment
+    spec:
+      containers:
+      - name: suricata-socket-container
+        image: ghcr.io/idaholab/malcolm/suricata:24.12.0
+        imagePullPolicy: Always
+        stdin: false
+        tty: true
+        envFrom:
+          - configMapRef:
+              name: process-env
+          - configMapRef:
+              name: ssl-env
+          - configMapRef:
+              name: upload-common-env
+          - configMapRef:
+              name: suricata-env
+          - configMapRef:
+              name: suricata-socket-env
+        livenessProbe:
+          exec:
+            command:
+            - supervisorctl
+            - status
+            - socket-suricata
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 15
+          successThreshold: 1
+          failureThreshold: 10
+        volumeMounts:
+          - mountPath: /var/local/ca-trust/configmap
+            name: suricata-socket-var-local-catrust-volume
+          - mountPath: /var/log/suricata
+            name: suricata-socket-suricata-logs-volume
+          - mountPath: "/opt/suricata/rules/configmap"
+            name: suricata-socket-custom-rules-volume
+          - mountPath: "/opt/suricata/include-configs/configmap"
+            name: suricata-socket-custom-configs-volume
+      initContainers:
+      - name: suricata-socket-dirinit-container
+        image: ghcr.io/idaholab/malcolm/dirinit:24.12.0
+        imagePullPolicy: Always
+        stdin: false
+        tty: true
+        envFrom:
+          - configMapRef:
+              name: process-env
+        env:
+          - name: PUSER_MKDIR
+            value: "/data/suricata-logs:socket"
+        volumeMounts:
+          - name: suricata-socket-suricata-logs-volume
+            mountPath: "/data/suricata-logs"
+      volumes:
+        - name: suricata-socket-var-local-catrust-volume
+          configMap:
+            name: var-local-catrust
+        - name: suricata-socket-suricata-logs-volume
+          persistentVolumeClaim:
+            claimName: suricata-claim
+        - name: suricata-socket-custom-rules-volume
+          configMap:
+            name: suricata-rules
+        - name: suricata-socket-custom-configs-volume
+          configMap:
+            name: suricata-configs

--- a/shared/bin/suricata_socket.py
+++ b/shared/bin/suricata_socket.py
@@ -21,7 +21,7 @@ class SuricataSocketClient:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.output_dir = output_dir
-        self.debug_enabled = True # change this to True to enable debug logging
+        self.debug_enabled = False # change this to True to enable debug logging
         self.debug_log = os.path.join(self.output_dir, 'socket_debug.log')
         
         # Ensure log directory exists

--- a/shared/bin/suricata_socket.py
+++ b/shared/bin/suricata_socket.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+import socket
+import time
+from typing import Optional, Dict, Any, Union
+
+class SuricataSocketClient:
+    """Client for communicating with Suricata's unix socket interface"""
+    
+    def __init__(self, 
+                 socket_path: str = '/var/run/suricata/suricata-command.socket',
+                 logger: Optional[logging.Logger] = None,
+                 max_retries: int = 30,
+                 retry_delay: int = 1,
+                 output_dir: str = '/var/log/suricata'):
+        self.socket_path = socket_path
+        self.logger = logger or logging.getLogger(__name__)
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.output_dir = output_dir
+        self.debug_enabled = True # change this to True to enable debug logging
+        self.debug_log = os.path.join(self.output_dir, 'socket_debug.log')
+        
+        # Ensure log directory exists
+        os.makedirs(os.path.dirname(self.debug_log), exist_ok=True)
+        
+        # Open debug log file
+        if(self.debug_enabled):
+            try:
+                with open(self.debug_log, 'a') as f:
+                    f.write("\n\n=== New Session Started ===\n\n")
+            except Exception as e:
+                self.logger.error(f"Failed to write to debug log {self.debug_log}: {e}")
+        
+        self._connect()
+
+    def _debug(self, msg: str) -> None:
+        if(not self.debug_enabled):
+           return
+
+        """Write a debug message to the log file and logger"""
+        try:
+            with open(self.debug_log, 'a') as f:
+                f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}\n")
+        except Exception as e:
+            self.logger.debug(f"Failed to write to debug log: {e}")
+        # Always log through logger as well
+        self.logger.debug(msg)
+
+    def _connect(self) -> None:
+        """Establish connection to Suricata socket with retries"""
+        attempts = 0
+        last_error = None
+        
+        while attempts < self.max_retries:
+            try:
+                self._debug(f"Attempt {attempts + 1}: Connecting to socket at {self.socket_path}")
+                self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.sock.settimeout(5)  # 5 second timeout
+                self.sock.connect(self.socket_path)
+                self._debug(f"Successfully connected to Suricata socket after {attempts+1} attempts")
+                
+                # Initial version handshake - this is a special case, not a command
+                handshake = json.dumps({"version": "0.1"}) + "\n"
+                self._debug(f"Sending handshake: {handshake.strip()}")
+                self.sock.send(handshake.encode('utf-8'))
+                
+                # Read response
+                response = self.sock.recv(4096).decode('utf-8')
+                self._debug(f"Handshake response: {response.strip()}")
+                
+                try:
+                    handshake_json = json.loads(response)
+                    if handshake_json.get("return") == "OK":
+                        self._debug("Handshake successful")
+                        return
+                    else:
+                        self._debug(f"ERROR: Unexpected handshake response: {handshake_json}")
+                        raise ConnectionError(f"Handshake failed: {handshake_json}")
+                except json.JSONDecodeError as e:
+                    self._debug(f"ERROR: Failed to decode handshake response: {e}")
+                    self._debug(f"ERROR: Raw response was: {repr(response)}")
+                    raise ConnectionError(f"Failed to decode handshake response: {e}")
+                
+            except socket.error as e:
+                last_error = e
+                attempts += 1
+                if attempts < self.max_retries:
+                    self._debug(f"ERROR: Socket connection failed: {e}")
+                    self._debug(f"Retrying in {self.retry_delay}s...")
+                    time.sleep(self.retry_delay)
+        
+        error_msg = f"Failed to connect after {self.max_retries} attempts: {last_error}"
+        self._debug(f"ERROR: {error_msg}")
+        raise ConnectionError(error_msg)
+
+    def _send_command(self, command: Dict[str, Any], retries: int = 3) -> Union[Dict[str, Any], None]:
+        """Send a command to Suricata socket and return the response"""
+        attempts = 0
+        while attempts < retries:
+            try:
+                # Convert command to JSON and send with newline
+                command_json = json.dumps(command) + "\n"
+                self._debug(f"\nSending command: {command_json.strip()}")
+                self.sock.send(command_json.encode('utf-8'))
+
+                # Read response
+                response = self.sock.recv(4096).decode('utf-8')
+                self._debug(f"Response received: {response.strip()}")
+
+                if not response:
+                    self._debug("ERROR: Empty response received")
+                    return None
+
+                try:
+                    decoded_response = json.loads(response)
+                    if decoded_response.get("return") == "NOK":
+                        self._debug(f"ERROR: Command failed: {decoded_response}")
+                        return None
+                    return decoded_response
+                except json.JSONDecodeError as e:
+                    self._debug(f"ERROR: Failed to decode response: {e}")
+                    self._debug(f"ERROR: Raw response was: {repr(response)}")
+                    if attempts + 1 >= retries:
+                        return None
+                    attempts += 1
+                    time.sleep(self.retry_delay)
+
+            except socket.error as e:
+                self._debug(f"ERROR: Socket error: {e}")
+                if attempts + 1 >= retries:
+                    return None
+                attempts += 1
+                time.sleep(self.retry_delay)
+                self._connect()
+
+        return None
+
+    def process_pcap(self, pcap_file: str, output_dir: str) -> bool:
+        """Submit a PCAP file to Suricata for processing"""
+        try:
+            self._debug(f"\nProcessing PCAP: {pcap_file}")
+            
+            # Create output directory if it doesn't exist
+            try:
+                os.makedirs(output_dir, exist_ok=True)
+                self._debug(f"Created output directory: {output_dir}")
+            except Exception as e:
+                self._debug(f"ERROR: Failed to create output directory {output_dir}: {e}")
+                return False
+            
+            command = {
+                "command": "pcap-file",
+                "arguments": {
+                    "filename": pcap_file,
+                    "output-dir": output_dir
+                }
+            }
+            submit_response = self._send_command(command)
+
+            if not submit_response or submit_response.get("return") != "OK":
+                self._debug(f"ERROR: Failed to process PCAP: {submit_response}")
+                return False
+
+            self._debug(f"Successfully processed PCAP: {pcap_file}")
+            return True
+
+        except Exception as e:
+            self._debug(f"ERROR: Exception processing PCAP: {e}")
+            return False
+
+    def close(self) -> None:
+        """Close the socket connection"""
+        try:
+            self.sock.close()
+        except Exception:
+            pass

--- a/suricata/scripts/docker_entrypoint.sh
+++ b/suricata/scripts/docker_entrypoint.sh
@@ -14,5 +14,12 @@ else
     /usr/local/bin/suricata_config_populate.py --suricata ${SURICATA_TEST_CONFIG_BIN} ${SURICATA_TEST_CONFIG_VERBOSITY:-} >&2
 fi
 
+# Create symlink for Suricata socket and set permissions
+mkdir -p /var/run/suricata
+chmod 755 /var/run/suricata
+ln -sf /var/run/suricata/suricata-command.socket /var/run/suricata-command.socket
+chmod 666 /var/run/suricata/suricata-command.socket || true
+chmod 666 /var/run/suricata-command.socket || true
+
 # start supervisor (which will spawn pcap-suricata, cron, etc.) or whatever the default command is
 exec "$@"

--- a/suricata/supervisord.conf
+++ b/suricata/supervisord.conf
@@ -74,7 +74,22 @@ redirect_stderr=true
 user=%(ENV_PUSER)s
 
 [program:socket-suricata]
-command=/usr/bin/suricata -vvv --unix-socket --set unix-command.enabled=true -c "%(ENV_SURICATA_CONFIG_FILE)s" -l "%(ENV_SURICATA_LOG_DIR)s"
+command=/bin/bash -c '\
+    mkdir -p /var/run/suricata && \
+    chmod 755 /var/run/suricata && \
+    ln -sf /var/run/suricata/suricata-command.socket /var/run/suricata-command.socket && \
+    /usr/bin/suricata -vvv \
+        --unix-socket \
+        --set unix-command.enabled=true \
+        -c "%(ENV_SURICATA_CONFIG_FILE)s" \
+        -l "%(ENV_SURICATA_LOG_DIR)s" & \
+    while true; do \
+        if [ -e /var/run/suricata/suricata-command.socket ]; then \
+            chmod 666 /var/run/suricata/suricata-command.socket; \
+            chmod 666 /var/run/suricata-command.socket 2>/dev/null || true; \
+        fi; \
+        sleep 1; \
+    done'
 directory=%(ENV_SURICATA_RUN_DIR)s
 autostart=true
 autorestart=true
@@ -88,16 +103,3 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 user=root
 priority=100
-
-[program:socket-permissions]
-command=/bin/bash -c "while true; do if [ -e /var/run/suricata/suricata-command.socket ]; then chmod 666 /var/run/suricata/suricata-command.socket; chmod 666 /var/run/suricata-command.socket 2>/dev/null || true; fi; sleep 1; done"
-autostart=true
-autorestart=true
-startsecs=1
-stopasgroup=true
-killasgroup=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-user=root
-priority=50

--- a/suricata/supervisord.conf
+++ b/suricata/supervisord.conf
@@ -72,3 +72,32 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 user=%(ENV_PUSER)s
+
+[program:socket-suricata]
+command=/usr/bin/suricata -vvv --unix-socket --set unix-command.enabled=true -c "%(ENV_SURICATA_CONFIG_FILE)s" -l "%(ENV_SURICATA_LOG_DIR)s"
+directory=%(ENV_SURICATA_RUN_DIR)s
+autostart=true
+autorestart=true
+startsecs=15
+stopwaitsecs=15
+startretries=3
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+user=root
+priority=100
+
+[program:socket-permissions]
+command=/bin/bash -c "while true; do if [ -e /var/run/suricata/suricata-command.socket ]; then chmod 666 /var/run/suricata/suricata-command.socket; chmod 666 /var/run/suricata-command.socket 2>/dev/null || true; fi; sleep 1; done"
+autostart=true
+autorestart=true
+startsecs=1
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+user=root
+priority=50


### PR DESCRIPTION
Addressing https://github.com/cisagov/Malcolm/issues/457

We can address whether we need 33-suricata-socket.yml. We can just merge that into 11-suricata.yml if we never intend to use the other way moving forward. Otherwise I implemented the socket logic in a new class and included that in pcap_processor.py. 

I then tested by spinning up a docker image with the pcap_watcher and moving PCAPs into the correct directory. For each PCAP placed in the input folder I was able to see a directory  be made with an eve.json within filled with suricata data. See attached screenshot.

![image](https://github.com/user-attachments/assets/f0299e2f-c873-4e40-94c2-35d900081bd0)
